### PR TITLE
fix: build wheel in tag-and-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+# Fallback: triggered by manual tag pushes (not automated ones).
+# The tag-and-release.yml workflow handles automated releases with wheel builds.
 on:
   push:
     tags:
@@ -37,7 +39,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v4
-      - name: Create Release
+      - name: Create or update Release
         uses: softprops/action-gh-release@v2
         with:
           files: wheels-*/*

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -14,7 +14,7 @@ jobs:
     # CIが成功したときのみ実行
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
-      contents: write  # タグのpushに必要
+      contents: write  # タグのpush + リリース作成に必要
       actions: write  # CIトリガーに必要
     steps:
       - name: Checkout
@@ -80,6 +80,32 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build wheel directly here — GITHUB_TOKEN tag pushes don't trigger
+      # the separate release.yml workflow, so we build inline.
+      - name: Setup Python
+        if: steps.version.outputs.skip != 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build wheels
+        if: steps.version.outputs.skip != 'true'
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist
+          manylinux: auto
+
+      - name: Upload wheel to GitHub Release
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            dist/*.whl \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # WorkflowからのpushはCIをトリガーしないため、明示的にCIを実行
       - name: Trigger CI for version bump commit


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` からのタグpushは他のworkflow (`release.yml`) をトリガーしない GitHub Actions の制約を修正
- `tag-and-release.yml` 内で直接 maturin ビルド + `gh release create` でwheelをアップロード
- `release.yml` は手動タグpush用のフォールバックとして維持

## 問題
v0.1.3, v0.1.4 のリリースにwheelが自動添付されなかった。手動ビルド+アップロードが必要だった。

## Test plan
- [ ] PRマージ後、次のCIパスでタグ+リリース+wheel が自動生成されることを確認