### PR TITLE
fix: use manylinux_2_28 for abi3 wheel builds (#15)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           target: x86_64
           args: --release --out dist
-          manylinux: auto
+          manylinux: manylinux_2_28
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           target: x86_64
           args: --release --out dist
-          manylinux: auto
+          manylinux: manylinux_2_28
 
       - name: Upload wheel to GitHub Release
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

v0.1.9 wheel が `cp38-cp38` タグでビルドされ、Python 3.12 環境でインストールできない問題を修正。

## Root Cause

maturin v1.12.2 → v1.12.5 で、manylinux2014 コンテナ内の Python 3.8 が abi3 非対応と判定されるようになった。

```
⚠️ Warning: CPython 3.8 does not yet support abi3 so the build artifacts will be version-specific.
📦 Built wheel for CPython 3.8 to dist/...-cp38-cp38-...whl
```

## Fix

`manylinux: auto` (= manylinux2014, Python 3.8) → `manylinux_2_28` (Python 3.11+) に変更。
manylinux_2_28 コンテナには Python 3.11+ が含まれるため、abi3 wheel が正しく生成される。

対象ファイル:
- `.github/workflows/tag-and-release.yml`
- `.github/workflows/release.yml`

## Test plan

- [ ] CI パス確認
- [ ] マージ後の tag-and-release で `cp311-abi3` wheel が生成されること

Closes #15