### PR TITLE
fix: balance Decimal truncation — fractional amounts reported as zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautilus-bitbank"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [lib]

--- a/nautilus_bitbank/execution.py
+++ b/nautilus_bitbank/execution.py
@@ -266,10 +266,10 @@ class BitbankExecutionClient(LiveExecutionClient):
                 self.log.debug(f"Skipping unknown currency: {asset_code}")
                 return
 
-            total_val = int(Decimal(data.get("onhand_amount", "0")))
-            locked_val = int(Decimal(data.get("locked_amount", "0")))
-            free_val = total_val - locked_val 
-            
+            total_val = Decimal(data.get("onhand_amount", "0"))
+            locked_val = Decimal(data.get("locked_amount", "0"))
+            free_val = total_val - locked_val
+
             balance = AccountBalance(
                 Money(total_val, currency),
                 Money(locked_val, currency),
@@ -659,8 +659,8 @@ class BitbankExecutionClient(LiveExecutionClient):
                     if currency is None:
                         continue  # Skip unknown currencies
                     
-                    total = int(Decimal(asset["onhand_amount"]))
-                    locked = int(Decimal(asset["locked_amount"]))
+                    total = Decimal(asset["onhand_amount"])
+                    locked = Decimal(asset["locked_amount"])
                     free = total - locked
                     
                     nautilus_balances.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nautilus-adapter-bitbank"
-version = "0.1.12"
+version = "0.1.13"
 description = "Bitbank adapter for NautilusTrader"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- `int(Decimal("0.1"))` evaluates to `0`, causing fractional crypto balances (e.g. 0.1 SOL) to be reported as zero
- Pass `Decimal` directly to `Money()` which handles precision correctly via currency precision settings

## Root Cause
```python
# Bug: int() truncates fractional values
total = int(Decimal(asset["onhand_amount"]))  # int(Decimal("0.1")) = 0

# Fix: Decimal passed directly to Money()
total = Decimal(asset["onhand_amount"])        # Decimal("0.1")
Money(total, currency)                         # 0.10000000 SOL ✓
```

## Affected Methods
- `generate_account_status_reports()` — initial balance fetch on connect
- `_process_asset_update()` — PubNub real-time balance updates

## Version
0.1.12 → 0.1.13